### PR TITLE
Header tooltips and inline updates

### DIFF
--- a/GitHub_Tweaks.user.js
+++ b/GitHub_Tweaks.user.js
@@ -106,7 +106,11 @@ GHT.addToggleableComments = function () {
     });
 
     // Set the mouse hover title of the header to the comment body to easily browse folded comments.
-    $f.attr('title', $f.next('.comment-content').find('.edit-comment-hide .comment-body').text().trim());
+    var content_text = $f.next('.comment-content').find('.edit-comment-hide .comment-body > p').text().trim();
+    var content_text_slice = content_text.slice(0, 111);
+    $f.addClass('tooltipped tooltipped-s');
+    $f.attr('aria-label', content_text_slice + ((content_text > content_text_slice) ? '...' : ''));
+
     // Add north-oriented tooltips to all reaction buttons.
     GHT.tooltipify($f.find('.timeline-comment-actions button'), 'n');
 

--- a/GitHub_Tweaks.user.js
+++ b/GitHub_Tweaks.user.js
@@ -104,6 +104,9 @@ GHT.addToggleableComments = function () {
     $f.find('.timeline-comment-header-text a').click(function(event) {
       event.stopPropagation();
     });
+
+    // Set the mouse hover title of the header to the comment body to easily browse folded comments.
+    $f.attr('title', $f.next('.comment-content').find('.edit-comment-hide .comment-body').text().trim());
     $f.click(function(event) {
       if (!jQuery(event.target).closest('.timeline-comment-actions').length) {
         GHT.sht($f.nextAll(), !$f.next(':visible').length);

--- a/GitHub_Tweaks.user.js
+++ b/GitHub_Tweaks.user.js
@@ -184,7 +184,8 @@ GHT.Observer = {
 
           // Observe child changes.
           mo.observe(toObserve, {
-            childList: true
+            childList: true,
+            subtree: true
           });
 
           GHT.Observer.observers.push(mo);

--- a/GitHub_Tweaks.user.js
+++ b/GitHub_Tweaks.user.js
@@ -87,7 +87,7 @@ GHT.addToggleableFileDiffs = function () {
       '#toc .btn-group.right'                          // ...to commit toolbar.
     )
       .first()
-      .after(GHT.getFoldUnfoldButtons($fhs.next(), 'diffbar-item right'));
+      .after(GHT.getFoldUnfoldButtons($fhs.next(), 'diffbar-item right', 's'));
   }
 };
 
@@ -107,6 +107,9 @@ GHT.addToggleableComments = function () {
 
     // Set the mouse hover title of the header to the comment body to easily browse folded comments.
     $f.attr('title', $f.next('.comment-content').find('.edit-comment-hide .comment-body').text().trim());
+    // Add north-oriented tooltips to all reaction buttons.
+    GHT.tooltipify($f.find('.timeline-comment-actions button'), 'n');
+
     $f.click(function(event) {
       if (!jQuery(event.target).closest('.timeline-comment-actions').length) {
         GHT.sht($f.nextAll(), !$f.next(':visible').length);
@@ -126,7 +129,7 @@ GHT.addToggleableComments = function () {
   if (!jQuery('.GHT.btn-group').length) {
     jQuery('.timeline-comment-actions')
       .first()
-      .prepend(GHT.getFoldUnfoldButtons($chs.nextAll()));
+      .prepend(GHT.getFoldUnfoldButtons($chs.nextAll(), '', 'n'));
   }
 };
 
@@ -217,19 +220,45 @@ GHT.sht = function($s, s) {
 };
 
 /**
+ * Add a pretty tooltip to the passed items.
+ *
+ * @param  {jQuery} $items Items to tooltipify.
+ * @param  {String} ttdir  Direction of the tooltip.
+ * @param  {String} title  Static title to override current values.
+ */
+GHT.tooltipify = function($items, ttdir, title) {
+  ttdir = ttdir ? (' tooltipped-' + ttdir) : '';
+  title = title || '';
+
+  $items.each(function() {
+    var $t = jQuery(this).addClass('tooltipped' + ttdir);
+
+    // Override title text?
+    if (title === '' && !$t.attr('aria-title') && $t.attr('title')) {
+      title = $t.attr('title');
+    }
+
+    $t.attr('aria-label', title);
+    $t.attr('title', '');
+  });
+};
+
+/**
  * Get a container with both the fold and unfold buttons.
  *
  * @param {jQuery} $items  Items to fold / unfold.
  * @param {String} classes Class(es) to add to the container.
+ * @param {String} ttdir   Direction of the tooptip.
  *
  * @return {jQuery} Buttons container.
  */
-GHT.getFoldUnfoldButtons = function($items, classes) {
+GHT.getFoldUnfoldButtons = function($items, classes, ttdir) {
+  ttdir = ttdir ? ('tooltipped-' + ttdir) : '';
   return jQuery('<div/>', {class: 'GHT btn-group'})
     .addClass(classes || '')
     .append(
-      GHT.getFoldButton($items),
-      GHT.getUnfoldButton($items)
+      GHT.getFoldButton($items).addClass(ttdir),
+      GHT.getUnfoldButton($items).addClass(ttdir)
     );
 };
 
@@ -241,7 +270,7 @@ GHT.getFoldUnfoldButtons = function($items, classes) {
  * @return {jQuery} The fold button.
  */
 GHT.getFoldButton = function($items) {
-  return jQuery('<div/>', {html: GHT.getOcticon('fold'), class: 'btn btn-sm tooltipped tooltipped-s'})
+  return jQuery('<div/>', {html: GHT.getOcticon('fold'), class: 'btn btn-sm tooltipped'})
     .attr('aria-label', 'Collapse All')
     .click(function() { $items.hide(); });
 };
@@ -254,7 +283,7 @@ GHT.getFoldButton = function($items) {
  * @return {jQuery} The unfold button.
  */
 GHT.getUnfoldButton = function($items) {
-  return jQuery('<div/>', {html: GHT.getOcticon('unfold'), class: 'btn btn-sm tooltipped tooltipped-s'})
+  return jQuery('<div/>', {html: GHT.getOcticon('unfold'), class: 'btn btn-sm tooltipped'})
     .attr('aria-label', 'Expand All')
     .click(function() { $items.show(); });
 };

--- a/GitHub_Tweaks.user.js
+++ b/GitHub_Tweaks.user.js
@@ -141,6 +141,8 @@ GHT.addToggleableComments = function () {
  * Start the party.
  */
 GHT.init = function () {
+  GHT.initCustomTriggers();
+
   // Add the global CSS rules.
   GM_addStyle(
     '.GHT.commit-ref:hover { background-color: rgba(0,0,0,.1); background-image: none; text-shadow: none; cursor: pointer; }' +
@@ -488,4 +490,19 @@ GHT.octicons =  {
   'watch' : { 'viewbox' : '0 0 12 16', 'path' : '<path d="M6 8h2v1H5V5h1v3zm6 0c0 2.22-1.2 4.16-3 5.19V15c0 .55-.45 1-1 1H4c-.55 0-1-.45-1-1v-1.81C1.2 12.16 0 10.22 0 8s1.2-4.16 3-5.19V1c0-.55.45-1 1-1h4c.55 0 1 .45 1 1v1.81c1.8 1.03 3 2.97 3 5.19zm-1 0c0-2.77-2.23-5-5-5S1 5.23 1 8s2.23 5 5 5 5-2.23 5-5z" fill-rule="evenodd"/>' },
   'x' : { 'viewbox' : '0 0 12 16', 'path' : '<path d="M7.48 8l3.75 3.75-1.48 1.48L6 9.48l-3.75 3.75-1.48-1.48L4.52 8 .77 4.25l1.48-1.48L6 6.52l3.75-3.75 1.48 1.48z" fill-rule="evenodd"/>' },
   'zap' : { 'viewbox' : '0 0 10 16', 'path' : '<path d="M10 7H6l3-7-9 9h4l-3 7z" fill-rule="evenodd"/>' },
+};
+
+/**
+ * Allow custom execution of internal triggers "show" and "hide".
+ *
+ * source: http://viralpatel.net/blogs/jquery-trigger-custom-event-show-hide-element/
+ */
+GHT.initCustomTriggers = function() {
+  jQuery.each(['show', 'hide'], function (i, ev) {
+    var el = jQuery.fn[ev];
+    jQuery.fn[ev] = function () {
+      this.trigger(ev);
+      return el.apply(this, arguments);
+    };
+  });
 };

--- a/GitHub_Tweaks.user.js
+++ b/GitHub_Tweaks.user.js
@@ -94,7 +94,7 @@ GHT.addToggleableFileDiffs = function () {
  */
 GHT.addToggleableComments = function () {
   var i = 0;
-  var $chs = jQuery('#discussion_bucket .timeline-comment-header').not('.GHT');
+  var $chs = jQuery('.timeline-comment-header').not('.GHT');
   $chs.each(function () {
     var $f = jQuery(this).addClass('GHT');
     $f.click(function(event) {

--- a/GitHub_Tweaks.user.js
+++ b/GitHub_Tweaks.user.js
@@ -65,17 +65,19 @@ GHT.addToggleableFileDiffs = function () {
   var $fhs = jQuery('#files.diff-view .file-header').not('.GHT');
   $fhs.each(function () {
     var $f = jQuery(this).addClass('GHT');
+
+    // When clicking the file actions, don't toggle the file contents.
+    $f.find('.file-actions').click(function(event) {
+      event.stopPropagation();
+    });
+
     $f.click(function() {
       $f.next().toggle();
     });
+
     i++;
   });
   GHT.debug && console.log('addToggleableFileDiffs: ' + i);
-
-  // When clicking the file actions, don't toggle the file contents.
-  jQuery('.file-actions').click(function(event) {
-    event.stopPropagation();
-  });
 
   if (!jQuery('.GHT.btn-group').length) {
     // Add collapse / expand buttons...
@@ -97,6 +99,11 @@ GHT.addToggleableComments = function () {
   var $chs = jQuery('.timeline-comment-header').not('.GHT');
   $chs.each(function () {
     var $f = jQuery(this).addClass('GHT');
+
+    // When clicking the comment header links, don't toggle the comment contents.
+    $f.find('.timeline-comment-header-text a').click(function(event) {
+      event.stopPropagation();
+    });
     $f.click(function(event) {
       if (!jQuery(event.target).closest('.timeline-comment-actions').length) {
         GHT.sht($f.nextAll(), !$f.next(':visible').length);
@@ -108,14 +115,10 @@ GHT.addToggleableComments = function () {
         $f.nextAll('.comment-reactions').show();
       }
     });
+
     i++;
   });
   GHT.debug && console.log('addToggleableComments: ' + i);
-
-  // When clicking the comment header links, don't toggle the comment contents.
-  jQuery('.timeline-comment-header-text a').click(function(event) {
-    event.stopPropagation();
-  });
 
   if (!jQuery('.GHT.btn-group').length) {
     jQuery('.timeline-comment-actions')

--- a/GitHub_Tweaks.user.js
+++ b/GitHub_Tweaks.user.js
@@ -106,10 +106,16 @@ GHT.addToggleableComments = function () {
     });
 
     // Set the mouse hover title of the header to the comment body to easily browse folded comments.
-    var content_text = $f.next('.comment-content').find('.edit-comment-hide .comment-body > p').text().trim();
-    var content_text_slice = content_text.slice(0, 111);
-    $f.addClass('tooltipped tooltipped-s');
-    $f.attr('aria-label', content_text_slice + ((content_text > content_text_slice) ? '...' : ''));
+    var content = $f.next('.comment-content').find('.edit-comment-hide .comment-body > p').text().trim();
+    var content_slice = content.slice(0, 111);
+    GHT.tooltipify($f, 's', content_slice + ((content > content_slice) ? '...' : ''));
+    // Don't show tooltip yet, only when content is hidden!
+    $f.removeClass('tooltipped');
+
+    // Show/hide the content tooltip in the header.
+    $f.next('.comment-content')
+      .on('show', function() { $f.removeClass('tooltipped'); })
+      .on('hide', function() { $f.addClass('tooltipped'); });
 
     // Add north-oriented tooltips to all reaction buttons.
     GHT.tooltipify($f.find('.timeline-comment-actions button'), 'n');

--- a/GitHub_Tweaks.user.js
+++ b/GitHub_Tweaks.user.js
@@ -238,8 +238,11 @@ GHT.tooltipify = function($items, ttdir, title) {
     var $t = jQuery(this).addClass('tooltipped' + ttdir);
 
     // Override title text?
-    if (title === '' && !$t.attr('aria-title') && $t.attr('title')) {
-      title = $t.attr('title');
+    if (title === '') {
+      title = $t.attr('aria-title');
+      if (!$t.attr('aria-title') && $t.attr('title')) {
+        title = $t.attr('title');
+      }
     }
 
     $t.attr('aria-label', title);

--- a/GitHub_Tweaks.user.js
+++ b/GitHub_Tweaks.user.js
@@ -106,7 +106,7 @@ GHT.addToggleableComments = function () {
     });
 
     // Set the mouse hover title of the header to the comment body to easily browse folded comments.
-    var content = $f.next('.comment-content').find('.edit-comment-hide .comment-body > p').text().trim();
+    var content = $f.next('.comment-content').find('.edit-comment-hide .comment-body').text().trim();
     var content_slice = content.slice(0, 111);
     GHT.tooltipify($f, 's', content_slice + ((content > content_slice) ? '...' : ''));
     // Don't show tooltip yet, only when content is hidden!

--- a/GitHub_Tweaks.user.js
+++ b/GitHub_Tweaks.user.js
@@ -3,7 +3,7 @@
 // @namespace   noplanman
 // @description Userscript that adds tweaks to GitHub.
 // @include     https://github.com*
-// @version     2.2
+// @version     2.3
 // @author      Armando Lüscher
 // @oujs:author noplanman
 // @copyright   2016 Armando Lüscher
@@ -124,10 +124,10 @@ GHT.addToggleableComments = function () {
       if (!jQuery(event.target).closest('.timeline-comment-actions').length) {
         GHT.sht($f.nextAll(), !$f.next(':visible').length);
       } else if (jQuery(event.target).hasClass('js-comment-edit-button')) {
-        // Edit buttons shows the comment.
+        // Edit button shows the comment.
         $f.nextAll('.comment-content').show();
       } else if (jQuery(event.target).hasClass('timeline-comment-action')) {
-        // Add Reaction buttons shows the reactions.
+        // Add Reaction button shows the reactions.
         $f.nextAll('.comment-reactions').show();
       }
     });

--- a/README.md
+++ b/README.md
@@ -45,10 +45,17 @@ Alternatively, you can collapse and expand all at the same time by clicking one 
 
 When viewing a conversation of an issue or PR, you can now collapse and expand the comments by clicking the individual comment headers.
 Alternatively, you can collapse and expand all at the same time by clicking one of the new buttons in the topmost comment header.
+For hidden comments, the first part of the content gets added to the comment header as a tooltip.
 
 ![Toggleable Comments](assets/ToggleableComments.png)
 
 ##Changelog
+
+###2.3
+
+- Refresh tweaks on page content change, so that new inline comments instantly become toggleable.
+- Add content tooltip to comment header when content is collapsed.
+- Add missing tooltips to comment action buttons.
 
 ###2.2
 


### PR DESCRIPTION
- Be less specific to allow inline comment folding too.
- Display the first part of the content on a tooltip in the comment headers to facilitate browsing when all comments are folded.
- Make tooltip direction for expand / collapse buttons customisable.
- Add missing tooltips to comment action buttons.
- Add tooltipify function to easily add a pretty tooltip to a group of items.
- Enable linking into "show" and "hide" triggers.
- Fix a few mini-typos.
